### PR TITLE
Deploy OPA when a policy is deployed, if not already running

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Ship will download and give you an opportunity to review the Kubernetes manifest
 You can then use `ship watch && ship update` to watch and configure updates as they are shipped here.
 
 For more information on the components, and other methods to install GateKeeper, [read the docs](https://github.com/replicatedhq/gatekeeper/tree/master/docs/).
+
+## Deploying Policies
+
+After installing GateKeeper to a cluster, a policy can be deployed using `kubectl apply -f ./config/samples/policies_v1alpha1_admissionpolicy.yaml`. (This is a sample policy that prevents any pod from using images tagged `:latest`). When the policy is applied, if OPA is running in the same namespace, the controller will delpoy the policy from the YAML to the OPA instance. If OPA is not found, the controller will provision a new OPA instance, and deploy the policy to that new instance, whne it's ready.
+
+This handles the TLS configuration, webhook configuration, and all underlying Kubernetes resources that are required to create a dynamic admission controller.
+
 ## Motivations
 
 The Open Policy Agent (OPA) project is an ambitious project that does much more than just Kubernetes Admission Controllers.

--- a/pkg/controller/admissionpolicy/reconcilers.go
+++ b/pkg/controller/admissionpolicy/reconcilers.go
@@ -10,22 +10,33 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 
 	"github.com/pkg/errors"
+	controllersv1alpha1 "github.com/replicatedhq/gatekeeper/pkg/apis/controllers/v1alpha1"
 	policiesv1alpha1 "github.com/replicatedhq/gatekeeper/pkg/apis/policies/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
-	serviceNamePrefix = "gatekeeper-opa"
-	secretNamePrefix  = "gatekeeper"
+	serviceNamePrefix    = "gatekeeper-opa"
+	secretNamePrefix     = "gatekeeper"
+	deploymentNamePrefix = "gatekeeper"
 )
 
 func (r *ReconcileAdmissionPolicy) reconcileAdmissionPolicy(instance *policiesv1alpha1.AdmissionPolicy) error {
 	if err := r.validatePolicy(instance); err != nil {
 		return errors.Wrap(err, "validate policy")
+	}
+
+	// Deploy any required OPA instances referenced by this policy
+	if err := r.ensureOPARunningForPolicy(instance); err != nil {
+		return errors.Wrap(err, "ensure opa running for policy")
 	}
 
 	if err := r.applyPolicy(instance); err != nil {
@@ -40,6 +51,100 @@ func (r *ReconcileAdmissionPolicy) validatePolicy(instance *policiesv1alpha1.Adm
 	return nil
 }
 
+func (r *ReconcileAdmissionPolicy) ensureOPARunningForPolicy(instance *policiesv1alpha1.AdmissionPolicy) error {
+	debug := level.Info(log.With(r.Logger, "method", "ensureOPARunningForPolicy"))
+	debug.Log("event", "ensure opa instance running", "failurePolicy", instance.Spec.FailurePolicy)
+
+	deploymentName := strings.ToLower(fmt.Sprintf("%s-%s", deploymentNamePrefix, instance.Spec.FailurePolicy))
+
+	foundDeployment := &appsv1.Deployment{}
+	err := r.Get(context.TODO(), types.NamespacedName{Name: deploymentName, Namespace: instance.Namespace}, foundDeployment)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrap(err, "find deployment for opa instance")
+	}
+
+	if err == nil {
+		if foundDeployment.Status.AvailableReplicas > 0 {
+			return nil
+		}
+
+		abortAt := time.Now().Add(time.Minute * 2)
+		for {
+			if time.Now().After(abortAt) {
+				return errors.Wrap(fmt.Errorf("timeout waiting for opa to be ready"), "waiting for opa")
+			}
+
+			foundDeployment := &appsv1.Deployment{}
+			err := r.Get(context.TODO(), types.NamespacedName{Name: deploymentName, Namespace: instance.Namespace}, foundDeployment)
+			if err != nil && !apierrors.IsNotFound(err) {
+				return errors.Wrap(err, "find deployment for opa instance")
+			}
+
+			// If the deployment isn't found, continue and check again
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+
+			if foundDeployment.Status.AvailableReplicas > 0 {
+				return nil
+			}
+
+		}
+	}
+
+	// Create the opa instance...
+	// ... using the _other_ controller, that we probably shouldn't assume exists, but we do for now
+
+	openPolicyAgent := &controllersv1alpha1.OpenPolicyAgent{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1alpha1",
+			Kind:       "OpenPolicyAgent",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentNamePrefix, // the controller will add a suffix
+			Namespace: instance.Namespace,
+		},
+		Spec: controllersv1alpha1.OpenPolicyAgentSpec{
+			Name: deploymentName,
+			EnabledFailureModes: &controllersv1alpha1.OpenPolicyAgentEnabledFailureModes{
+				Ignore: instance.Spec.FailurePolicy == "Ignore",
+				Fail:   instance.Spec.FailurePolicy == "Fail",
+			},
+		},
+	}
+	if err = r.Create(context.TODO(), openPolicyAgent); err != nil {
+		return errors.Wrap(err, "creating open policy agent")
+	}
+
+	// block until this has been created
+	abortAt := time.Now().Add(time.Minute * 2)
+	for {
+		if time.Now().After(abortAt) {
+			return errors.Wrap(fmt.Errorf("timeout waiting for opa to be created"), "waiting for opa")
+		}
+
+		debug.Log("event", "polling for deployment to be ready")
+		foundDeployment := &appsv1.Deployment{}
+		err := r.Get(context.TODO(), types.NamespacedName{Name: deploymentName, Namespace: instance.Namespace}, foundDeployment)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return errors.Wrap(err, "find deployment for opa instance")
+		}
+
+		// If the deployment isn't found, continue and check again
+		if apierrors.IsNotFound(err) {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		debug.Log("event", "found deployment", "available replicas", foundDeployment.Status.AvailableReplicas)
+		if foundDeployment.Status.AvailableReplicas > 0 {
+			return nil
+		}
+
+		time.Sleep(time.Second)
+	}
+}
+
 func (r *ReconcileAdmissionPolicy) buildOpaURIForFailurePolicy(instance *policiesv1alpha1.AdmissionPolicy) string {
 	suffix := strings.ToLower(instance.Spec.FailurePolicy)
 	serviceName := fmt.Sprintf("%s-%s.%s.svc", serviceNamePrefix, suffix, instance.Namespace)
@@ -48,6 +153,9 @@ func (r *ReconcileAdmissionPolicy) buildOpaURIForFailurePolicy(instance *policie
 }
 
 func (r *ReconcileAdmissionPolicy) applyPolicy(instance *policiesv1alpha1.AdmissionPolicy) error {
+	debug := level.Info(log.With(r.Logger, "method", "applyPolicy"))
+	debug.Log("event", "applyPolicy", "name", instance.Name)
+
 	opaURI := r.buildOpaURIForFailurePolicy(instance)
 
 	// Get the CA from the secret so we can communicate

--- a/pkg/controller/openpolicyagent/reconcilers.go
+++ b/pkg/controller/openpolicyagent/reconcilers.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	serviceNamePrefix = "gatekeeper-opa"
-	secretNamePrefix  = "gatekeeper"
+	serviceNamePrefix    = "gatekeeper-opa"
+	secretNamePrefix     = "gatekeeper"
+	deploymentNamePrefix = "gatekeeper"
 )
 
 func (r *ReconcileOpenPolicyAgent) reconcileOpenPolicyAgent(instance *controllersv1alpha1.OpenPolicyAgent) error {
@@ -272,7 +273,7 @@ func (r *ReconcileOpenPolicyAgent) reconcileOpenPolicyAgentService(instance *con
 func (r *ReconcileOpenPolicyAgent) isOpenPolicyAgentDeploymentReady(instance *controllersv1alpha1.OpenPolicyAgent, failurePolicy string) (bool, error) {
 	debug := level.Info(log.With(r.Logger, "method", "reconcileOpenPolicyAgent.isOpenPolicyAgentDeploymentReady"))
 
-	deploymentName := strings.ToLower(fmt.Sprintf("%s-%s", instance.Name, failurePolicy))
+	deploymentName := strings.ToLower(fmt.Sprintf("%s-%s", deploymentNamePrefix, failurePolicy))
 	secretName := strings.ToLower(fmt.Sprintf("%s-%s", secretNamePrefix, failurePolicy))
 
 	foundSecret := &corev1.Secret{}
@@ -373,7 +374,7 @@ func (r *ReconcileOpenPolicyAgent) deleteOpenPolicyAgentDeployment(instance *con
 func (r *ReconcileOpenPolicyAgent) reconcileOpenPolicyAgentDeployment(instance *controllersv1alpha1.OpenPolicyAgent, failurePolicy string) error {
 	debug := level.Info(log.With(r.Logger, "method", "reconcileOpenPolicyAgent.reconcileOpenPolicyAgentDeployment"))
 
-	deploymentName := strings.ToLower(fmt.Sprintf("%s-%s", instance.Name, failurePolicy))
+	deploymentName := strings.ToLower(fmt.Sprintf("%s-%s", deploymentNamePrefix, failurePolicy))
 	secretName := strings.ToLower(fmt.Sprintf("%s-%s", secretNamePrefix, failurePolicy))
 
 	// Deployment


### PR DESCRIPTION
This is a first pass at automatically deploying the OPA controller when a policy is deployed that doesn't have a matching deployment running.

This has a couple of assumptions that may work for now, but aren't valid eventually:

1. It creates a custom resource and assumes that deploying a custom resources will create OPA. Perhaps it should be refactored to just deploy OPA without creating a custom resource, if the CRD is not installed?

2. The reconciler for the policy controller blocks by polling the k8s api to determine when OPA is running. This could be an informer to be nicer to the API server.